### PR TITLE
Fixed some issues for Windows users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ All src files are located in the `app` folder.
 - `npm start` watches for file changes and automatically recompiles and reloads the web page. A local web server is started at `http://localhost:3333`
 - `npm build` creates a production build in the `public` folder with minified css and js.
 
+### Windows users
+Make sure npm is added to PATH.
+- `npm run start-windows` instead of `npm start`
+- `npm run build-windows` instead of `npm build` 
+
+
 ## TODO
 - Remove autoprefixer-brunch and replace with brunch-postcss when all issues are resolved https://github.com/brunch/brunch/pull/1664
 - Use specific version instead of commit hash for eslint-brunch when a new tag is created https://github.com/brunch/eslint-brunch/issues/22

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf public",
     "start": "npm run clean && node_modules/.bin/brunch watch --server",
     "build": "npm run clean && node_modules/.bin/brunch build --production",
-	"clean-windows": "if exist public echo RMDIR /s /q public",
+	  "clean-windows": "if exist public echo RMDIR /s /q public",
     "start-windows": "npm run clean-windows & .\\node_modules\\.bin\\brunch watch --server",
     "build-windows": "npm run clean-windows & .\\node_modules\\.bin\\brunch build --production"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rm -rf public",
     "start": "npm run clean && node_modules/.bin/brunch watch --server",
     "build": "npm run clean && node_modules/.bin/brunch build --production",
-	  "clean-windows": "if exist public echo RMDIR /s /q public",
+    "clean-windows": "if exist public echo RMDIR /s /q public",
     "start-windows": "npm run clean-windows & .\\node_modules\\.bin\\brunch watch --server",
     "build-windows": "npm run clean-windows & .\\node_modules\\.bin\\brunch build --production"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "scripts": {
     "clean": "rm -rf public",
     "start": "npm run clean && node_modules/.bin/brunch watch --server",
-    "build": "npm run clean && node_modules/.bin/brunch build --production"
+    "build": "npm run clean && node_modules/.bin/brunch build --production",
+	"clean-windows": "if exist public echo RMDIR /s /q public",
+    "start-windows": "npm run clean-windows & .\\node_modules\\.bin\\brunch watch --server",
+    "build-windows": "npm run clean-windows & .\\node_modules\\.bin\\brunch build --production"
   },
   "devDependencies": {
     "auto-reload-brunch": "^2",


### PR DESCRIPTION
Since bash commands won't work for Windows users unless they run in a bash shell, I added npm scripts with ms-batch syntax. Windows users have to run `npm run start-windows` and `npm run build-windows`.

We could probably move the scripts this to a .js file and check for OS, then execute the correct commands based on that, but I'll leave that for you to decide.